### PR TITLE
Importing print_function to allow python3 compilation

### DIFF
--- a/Python/piconzero.py
+++ b/Python/piconzero.py
@@ -1,6 +1,8 @@
 # Python library for 4tronix Picon Zero
 # Note that all I2C accesses are wrapped in try clauses with repeats
 
+from __future__ import print_function
+
 import smbus, time
  
 bus = smbus.SMBus(1) # For revision 1 Raspberry Pi, change to bus = smbus.SMBus(0)
@@ -33,7 +35,7 @@ def getRevision():
             return [rval/256, rval%256]
         except:
             if (DEBUG):
-                print "Error in getRevision(), retrying"
+                print("Error in getRevision(), retrying")
 #---------------------------------------------
 
 
@@ -49,7 +51,7 @@ def setMotor (motor, value):
                 break
             except:
                 if (DEBUG):
-                    print "Error in setMotor(), retrying"
+                    print("Error in setMotor(), retrying")
 
 def forward (speed):
     setMotor (0, speed)
@@ -83,7 +85,7 @@ def readInput (channel):
                 return bus.read_word_data (pzaddr, channel + 1)
             except:
                 if (DEBUG):
-                    print "Error in readChannel(), retrying"
+                    print("Error in readChannel(), retrying")
                 
 #---------------------------------------------
     
@@ -98,7 +100,7 @@ def setOutputConfig (output, value):
                 break
             except:
                 if (DEBUG):
-                    print "Error in setOutputConfig(), retrying"
+                    print("Error in setOutputConfig(), retrying")
 #---------------------------------------------
 
 #---------------------------------------------
@@ -114,7 +116,7 @@ def setInputConfig (channel, value, pullup = False):
                 break
             except:
                 if (DEBUG):
-                    print "Error in setInputConfig(), retrying"
+                    print("Error in setInputConfig(), retrying")
 #---------------------------------------------
 
 #---------------------------------------------
@@ -132,7 +134,7 @@ def setOutput (channel, value):
                 break
             except:
                 if (DEBUG):
-                    print "Error in setOutput(), retrying"
+                    print("Error in setOutput(), retrying")
 #---------------------------------------------
 
 #---------------------------------------------
@@ -145,7 +147,7 @@ def setPixel (Pixel, Red, Green, Blue, Update=True):
             break
         except:
             if (DEBUG):
-                print "Error in setPixel(), retrying"
+                print("Error in setPixel(), retrying")
 
 def setAllPixels (Red, Green, Blue, Update=True):
     pixelData = [100, Red, Green, Blue]
@@ -155,7 +157,7 @@ def setAllPixels (Red, Green, Blue, Update=True):
             break
         except:
             if (DEBUG):
-                print "Error in setAllPixels(), retrying"
+                print("Error in setAllPixels(), retrying")
 
 def updatePixels ():
     for i in range(RETRIES):
@@ -164,7 +166,7 @@ def updatePixels ():
             break
         except:
             if (DEBUG):
-                print "Error in updatePixels(), retrying"
+                print("Error in updatePixels(), retrying")
                         
 #---------------------------------------------
 
@@ -177,7 +179,7 @@ def setBrightness (brightness):
             break
         except:
             if (DEBUG):
-                print "Error in setBrightness(), retrying"
+                print("Error in setBrightness(), retrying")
 #---------------------------------------------
 
 #---------------------------------------------
@@ -190,10 +192,10 @@ def init (debug=False):
             break
         except:
             if (DEBUG):
-                print "Error in init(), retrying"
+                print("Error in init(), retrying")
     time.sleep(0.01)  #1ms delay to allow time to complete
     if (DEBUG):
-        print "Debug is", DEBUG
+        print("Debug is", DEBUG)
 #---------------------------------------------
 
 #---------------------------------------------
@@ -205,7 +207,7 @@ def cleanup ():
             break
         except:
             if (DEBUG):
-                print "Error in cleanup(), retrying"
+                print("Error in cleanup(), retrying")
     time.sleep(0.001)   # 1ms delay to allow time to complete
 #---------------------------------------------
 


### PR DESCRIPTION
In addition all the print statements have been updated to have parens.

I've tested backwards compatibility by running each of the example scripts (with the exception of sonarTest.py due to a missing import). I don't have all the hardware to fully test each example except for the servo test.

I tested python3 compatibility by writing up a little servo test program which pulled in piconzero.py.

fixes #1 
