### PR TITLE
Read Pwm input

### DIFF
--- a/Arduino/PiconZero09/PiconZero09.ino
+++ b/Arduino/PiconZero09/PiconZero09.ino
@@ -31,10 +31,10 @@ Register  Name      Type  Values
 11  Output3_Data    Byte  Data value(s)
 12  Output4_Data    Byte  Data value(s)
 13  Output5_Data    Byte  Data value(s)
-14  Input0_Config   Byte  0: Digital, 1:Analog, 2:DS18B20, 3:DHT11 (NB. 0x80 is Digital input with pullup), 4:PWM
-15  Input1_Config   Byte  0: Digital, 1:Analog, 2:DS18B20, 3:DHT11 (NB. 0x80 is Digital input with pullup), 4:PWM 
-16  Input2_Config   Byte  0: Digital, 1:Analog, 2:DS18B20, 3:DHT11 (NB. 0x80 is Digital input with pullup), 4:PWM
-17  Input3_Config   Byte  0: Digital, 1:Analog, 2:DS18B20, 3:DHT11 (NB. 0x80 is Digital input with pullup), 4:PWM
+14  Input0_Config   Byte  0: Digital, 1:Analog, 2:DS18B20, 3:DHT11 (NB. 0x80 is Digital input with pullup), 4:Duty Cycle 5: PW
+15  Input1_Config   Byte  0: Digital, 1:Analog, 2:DS18B20, 3:DHT11 (NB. 0x80 is Digital input with pullup), 4:Duty Cycle 5: PW
+16  Input2_Config   Byte  0: Digital, 1:Analog, 2:DS18B20, 3:DHT11 (NB. 0x80 is Digital input with pullup), 4:Duty Cycle 5: PW
+17  Input3_Config   Byte  0: Digital, 1:Analog, 2:DS18B20, 3:DHT11 (NB. 0x80 is Digital input with pullup), 4:Duty Cycle 5: PW
 18  Set Brightness  Byte  0..255. Scaled max brightness (default is 40)
 19  Update Pixels   Byte  dummy value - forces updating of neopixels
 20  Reset           Byte  dummy value - resets all values to initial state

--- a/Python/piconzero.py
+++ b/Python/piconzero.py
@@ -16,6 +16,7 @@ INCFG0 = 14
 SETBRIGHT = 18
 UPDATENOW = 19
 RESET = 20
+INPERIOD0 = 21
 #---------------------------------------------
 
 #---------------------------------------------
@@ -103,14 +104,16 @@ def setOutputConfig (output, value):
 
 #---------------------------------------------
 # Set configuration of selected input channel
-# 0: Digital, 1: Analog
-def setInputConfig (channel, value, pullup = False):
-    if (channel>=0 and channel <=3 and value>=0 and value<=3):
-        if (value==0 and pullup==True):
+# 0: Digital, 1: Analog, 2: DS18B20, 4: DutyCycle 5: Pulse Width
+def setInputConfig (channel, value, pullup = False, period = 2000):
+    if (channel >= 0 and channel <= 3 and value >= 0 and value <= 5):
+        if (value == 0 and pullup == True):
             value = 128
         for i in range(RETRIES):
             try:
                 bus.write_byte_data (pzaddr, INCFG0 + channel, value)
+                if (value == 4 or value == 5):
+                    bus.write_word_data (pzaddr, INPERIOD0 + channel, period)
                 break
             except:
                 if (DEBUG):


### PR DESCRIPTION
This pull request adds the ability for the picon zero to read PWM input in two forms.

1. PWM input can be read in and reported as the duty cycle.
2. PWM input can be read in and reported as simply the Pulse Width. This is mainly for cases where there is a very large period and the duty cycle is not precise enough.

To use simply set the python function `setInputConfig` to 4 for Duty Cycle or 5 for PW. The period defaults to 2000 microseconds or can be set.

`pz.setInputConfig(0, 5, period = 2200)`

To get the value back use the read input function.

`pz.readInput(0)`

Behind the scenes in the Arduino code we use a new dependency [EnableInterupt](https://github.com/GreyGnome/EnableInterrupt) to capture the signal edges on the input pins, then measure the time between high and low edges to determine the pulse width. See Issue #4 for more explanation.

Fixes #4